### PR TITLE
Add support for git worktrees

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,9 @@ function calculateURL() {
 
         console.log('gitDir is a file, checking to see if worktree', { text })
 
-        if (text.slice(0, 8) === 'gitdir: ') {
+        const worktreePrefix = 'gitdir: ';
+
+        if (text.startsWith(worktreePrefix)) {
             // gitdir points to worktree subdir of the real gitdir
             gitDir = path.join(text.slice(worktreePrefix.length).trim(), '..', '..');
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ function calculateURL() {
 
         if (text.slice(0, 8) === 'gitdir: ') {
             // gitdir points to worktree subdir of the real gitdir
-            gitDir = path.join(text.slice(8).trim(), '../..')
+            gitDir = path.join(text.slice(worktreePrefix.length).trim(), '..', '..');
         }
     }
 


### PR DESCRIPTION
Fixes #4.

In a git worktree, the `.git` of the working directory is a file that contains `gitdir: /path/to/real/git/root/.git/worktrees`. 

This PR detects if `.git` is a file and if so resolves the path within that file to the real `.git` dir.

And thanks for this extension, it's extremely useful!!!