### PR TITLE
Enable GitHub Enterprise / Self-Hosted repositories 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     ],
     "activationEvents": [
         "onCommand:githublinker.copyLink",
+        "onCommand:githublinker.openLink",
         "onCommand:githublinker.copyMarkdown"
     ],
     "main": "./out/extension",
@@ -29,6 +30,11 @@
             },
             {
                 "when": "editorHasSelection",
+                "command": "githublinker.openLink",
+                "title": "GitHub linker: Open link to selection in browser"
+            },
+            {
+                "when": "editorHasSelection",
                 "command": "githublinker.copyMarkdown",
                 "title": "GitHub linker: Copy link to selection and code as markdown"
             }
@@ -38,6 +44,11 @@
                 {
                     "when": "editorHasSelection",
                     "command": "githublinker.copyLink",
+                    "group": "9_cutcopypaste"
+                },
+                {
+                    "when": "editorHasSelection",
+                    "command": "githublinker.openLink",
                     "group": "9_cutcopypaste"
                 },
                 {
@@ -66,6 +77,7 @@
         "@types/clipboardy": "^1.1.0",
         "@types/ini": "^1.3.30",
         "clipboardy": "^1.2.3",
-        "ini": "^1.3.5"
+        "ini": "^1.3.5",
+        "open": "^7.0.2"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,13 +10,17 @@ import * as clipboardy from 'clipboardy';
 
 function getGitHubRepoURL(url: string) {
     if (url.endsWith('.git')) {
-        url = url.substring(0, url.length - '.git'.length);
+        url = url.substring(0, url.length - '.git'.length)
     }
-    if (url.startsWith('https://github.com/')) {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
         return url;
     }
-    if (url.startsWith('git@github.com:')) {
-        return 'https://github.com/' + url.substring('git@github.com:'.length);
+    if (url.startsWith('git@')) {
+        var domainList = url.match("git@(.+):.+$");
+        if (domainList) {
+            var domain = domainList[1];
+            return 'https://' + domain + '/' + url.substring(('git@' + domain + ':').length);
+        }
     }
     return null;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as ini from 'ini';
 import * as clipboardy from 'clipboardy';
+import * as open from 'open';
 
 function getGitHubRepoURL(url: string) {
     if (url.endsWith('.git')) {
@@ -120,6 +121,16 @@ export function activate(context: vscode.ExtensionContext) {
             const finalURL = calculateURL();
             clipboardy.writeSync(finalURL);
             vscode.window.showInformationMessage('GitHub URL copied to the clipboard!');
+        } catch (err) {
+            vscode.window.showErrorMessage(err.message);
+            throw err;
+        }
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('githublinker.openLink', () => {
+        try {
+            open(calculateURL())
+            vscode.window.showInformationMessage('GitHub URL opened by system handler!');
         } catch (err) {
             vscode.window.showErrorMessage(err.message);
             throw err;


### PR DESCRIPTION
This fixes issue #9 by duplicating the relevant portion code from  
https://github.com/morganwu277/github-linker/commit/394aac500c2a428b14319be0c8d1b56ba38d150e

I've built an installable extension (`.vsix`) with this modification and made it available here:
https://github.com/BloxBitBlit/github-linker/blob/release/release/github-linker-0.2.3.vsix