### PR TITLE
Remove unnecessary URL anchors and display command on `editorTextFocus` context

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "contributes": {
         "commands": [
             {
-                "when": "editorHasSelection",
+                "when": "editorTextFocus || editorHasSelection",
                 "command": "githublinker.copyLink",
                 "title": "GitHub linker: Copy link to selection"
             },
             {
-                "when": "editorHasSelection",
+                "when": "editorTextFocus || editorHasSelection",
                 "command": "githublinker.copyMarkdown",
                 "title": "GitHub linker: Copy link to selection and code as markdown"
             }
@@ -36,12 +36,12 @@
         "menus": {
             "editor/context": [
                 {
-                    "when": "editorHasSelection",
+                    "when": "editorTextFocus || editorHasSelection",
                     "command": "githublinker.copyLink",
                     "group": "9_cutcopypaste"
                 },
                 {
-                    "when": "editorHasSelection",
+                    "when": "editorTextFocus || editorHasSelection",
                     "command": "githublinker.copyMarkdown",
                     "group": "9_cutcopypaste"
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,8 +106,15 @@ function calculateURL() {
     const end = selection.end.line + 1;
 
     const relativePathURL = relativePath.split(path.sep).join('/');
+    const absolutePathURL = `${repoURL}/blob/${sha}/${relativePathURL}`;
 
-    return `${repoURL}/blob/${sha}/${relativePathURL}#L${start}-L${end}`;
+    if (start === 1 && end === document.lineCount) {
+        return absolutePathURL;
+    } else if (start === end) {
+        return `${absolutePathURL}#L${start}`;
+    }
+
+    return `${absolutePathURL}#L${start}-L${end}`;
 }
 
 export function activate(context: vscode.ExtensionContext) {


### PR DESCRIPTION
Hello! This PR adds two improvements:

### 1. Remove unnecessary URL anchors (94663c8b95a727d2bbdfe38361354260a84f218c)

GitHub allows for three different URL anchor "formats" for highlighting line numbers:
- `#L14-L32`: Highlight lines 14 through 32 (inclusive)
- `#L14`: Only highlight line 14
- _none_: Don't highlight any lines (just link to the whole file)

This PR creates cleaner looking URLs by adding support for the last two formats.
<br/>
### 2. Display command on `editorTextFocus` context (f57cc4cb668f40ae1616f9e3c89890642716d9a6)

At the moment, the Github Linker commands will not show up in the context menu when right-clicking on a single line (without first selecting some text). This PR adds support for that by adding the `editorTextFocus` context to the command's [when clauses](https://code.visualstudio.com/api/references/when-clause-contexts#available-contexts).

I think the existing `calculateURL()` function should be able to handle this since the VS Code editor [selection](https://code.visualstudio.com/api/references/vscode-api#Selection) will still contain a line start and end.

---

<details>
<summary>These are untested since I'm having issues with the `postinstall` script!</summary>

ERROR:
![image](https://user-images.githubusercontent.com/20099646/148155955-b23461f4-5bf9-4b51-99d8-f6b5196d65a4.png)

</details>