### PR TITLE
Support org repos in the remote url

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,8 @@ import * as fs from 'fs';
 import * as ini from 'ini';
 import * as clipboardy from 'clipboardy';
 
+const GITHUB_REGEX = /^.*?@github.com:(.*)$/gi;
+
 function getGitHubRepoURL(url: string) {
     if (url.endsWith('.git')) {
         url = url.substring(0, url.length - '.git'.length);
@@ -15,10 +17,11 @@ function getGitHubRepoURL(url: string) {
     if (url.startsWith('https://github.com/')) {
         return url;
     }
-    if (url.startsWith('git@github.com:')) {
-        return 'https://github.com/' + url.substring('git@github.com:'.length);
+    const match = [...url.matchAll(GITHUB_REGEX)];
+    if (!match.length) {
+      return null;
     }
-    return null;
+    return 'https://github.com/' + match[0][1];
 }
 
 function findGitFolder(fileName: string): string {


### PR DESCRIPTION
Some private organisation repos (I think GH Enterprise ones? I'm not 100% sure) have a .git URL that looks like this: `org-1234567@github.com:Organisation/repo.git`. This PR just tweaks `getGitHubRepoURL` to support git URLs of this form.